### PR TITLE
TT-2141 Verify each connection manually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 ## Unreleased
 ### Added
 - [TT-1392] Changelog file
+- [TT-2141] Only verify connections for Rails 3

--- a/lib/background_worker.rb
+++ b/lib/background_worker.rb
@@ -25,7 +25,9 @@ module BackgroundWorker
 
   def self.verify_active_connections!
     Rails.cache.reconnect if defined?(Rails)
-    ActiveRecord::Base.verify_active_connections! if defined?(ActiveRecord)
+    if defined?(ActiveRecord) && ActiveRecord::VERSION::MAJOR == 3
+      ActiveRecord::Base.verify_active_connections!
+    end
   end
 
   def self.after_exception(e)


### PR DESCRIPTION
Rails 4 no longer supports ActiveRecord::Base.verify_active_connections! so we must verify each one manually.

https://travellink-technology.atlassian.net/browse/TT-2141

**Testing**

Run a background worker task using rails 4 branch.