### PR TITLE
RU-79 Release connections after execution for Rails 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## Unreleased
 
+- [RU-79] Release connections after execution for Rails 4
+
 ## 0.1.0
 ### Added
 - [TT-1392] Changelog file

--- a/lib/background_worker.rb
+++ b/lib/background_worker.rb
@@ -30,6 +30,12 @@ module BackgroundWorker
     end
   end
 
+  def self.release_connections!
+    if defined?(ActiveRecord) && ActiveRecord::VERSION::MAJOR == 4
+      ActiveRecord::Base.clear_all_connections!
+    end
+  end
+
   def self.after_exception(e)
     config.after_exception(e)
   end

--- a/lib/background_worker.rb
+++ b/lib/background_worker.rb
@@ -31,7 +31,7 @@ module BackgroundWorker
   end
 
   def self.release_connections!
-    if defined?(ActiveRecord) && ActiveRecord::VERSION::MAJOR == 4
+    if defined?(ActiveRecord) && ActiveRecord::VERSION::MAJOR >= 4
       ActiveRecord::Base.clear_all_connections!
     end
   end

--- a/lib/background_worker/base.rb
+++ b/lib/background_worker/base.rb
@@ -84,6 +84,8 @@ module BackgroundWorker
         worker = new(options)
         execution = WorkerExecution.new(worker, method_name, options)
         execution.call
+
+        BackgroundWorker.release_connections!
       end
     end
   end

--- a/lib/background_worker/base.rb
+++ b/lib/background_worker/base.rb
@@ -84,7 +84,7 @@ module BackgroundWorker
         worker = new(options)
         execution = WorkerExecution.new(worker, method_name, options)
         execution.call
-
+      ensure
         BackgroundWorker.release_connections!
       end
     end


### PR DESCRIPTION
**Why**

Database connections were not being released after worker execution causing the app to time out.

**Testing**

Run feature tests in QT and see that connections get released from the pool. `SHOW FULL PROCESSLIST;` in mysql should show < 5 after tests run.