### PR TITLE
[PLAT-664] Align interface to ActiveJob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).  
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).  
 
+## Unreleased
+
+- [PLAT-664] Align interface to ActiveJob
+
 ## 0.5.0
 
 - [PLAT-183] Ruby 3.1, Rails 7.0 and push coverage with github action

--- a/lib/background_worker/base.rb
+++ b/lib/background_worker/base.rb
@@ -58,7 +58,7 @@ module BackgroundWorker
       end
 
       # Public method to do in background...
-      def perform_in_background(method_name, options = {})
+      def perform_later(method_name, options = {})
         opts = options.symbolize_keys
 
         method_name = method_name.to_sym
@@ -76,7 +76,7 @@ module BackgroundWorker
       # This method is called by the job runner
       #
       # It will just call your preferred method in the worker.
-      def perform(method_name, options = {})
+      def perform_now(method_name, options = {})
         BackgroundWorker.verify_active_connections! if BackgroundWorker.config.backgrounded
 
         worker = new(options)

--- a/lib/background_worker/config.rb
+++ b/lib/background_worker/config.rb
@@ -28,7 +28,7 @@ module BackgroundWorker
     end
 
     def foreground_enqueue(klass, method_name, opts)
-      klass.perform(method_name, opts)
+      klass.perform_now(method_name, opts)
     end
 
     def default_after_exception(e)

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -32,7 +32,7 @@ describe BackgroundWorker::Base do
 
   it 'should perform action and handle transactions/connections appropriately' do
     Model.transaction do
-      worker_class.perform_in_background(:store_in_cache, value: 42)
+      worker_class.perform_later(:store_in_cache, value: 42)
     end
     expect(cache).to have_received(:store).with(42)
   end


### PR DESCRIPTION
### WHY
We want to rebuild the public interface of this class to align with ActiveJob, so that we could migrate QT workers to ActiveJob much easier