### PR TITLE
[PLAT-670] Add queue_as method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).  
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).  
 
+## Unreleased
+
+- [PLAT-670] Add queue_as method
+
 ## 0.6.0
 
 - [PLAT-664] Align interface to ActiveJob

--- a/lib/background_worker/base.rb
+++ b/lib/background_worker/base.rb
@@ -53,7 +53,7 @@ module BackgroundWorker
     end
 
     class << self
-      attr_accessor :queue
+      attr_reader :queue
       def get_state_of(worker_id)
         BackgroundWorker::PersistentState.get_state_of(worker_id)
       end

--- a/lib/background_worker/base.rb
+++ b/lib/background_worker/base.rb
@@ -85,6 +85,10 @@ module BackgroundWorker
       ensure
         BackgroundWorker.release_connections! if BackgroundWorker.config.backgrounded
       end
+
+      def queue_as(queue = nil)
+        @queue = queue&.to_sym || :default
+      end
     end
   end
 end

--- a/lib/background_worker/base.rb
+++ b/lib/background_worker/base.rb
@@ -53,6 +53,7 @@ module BackgroundWorker
     end
 
     class << self
+      attr_accessor :queue
       def get_state_of(worker_id)
         BackgroundWorker::PersistentState.get_state_of(worker_id)
       end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -36,4 +36,11 @@ describe BackgroundWorker::Base do
     end
     expect(cache).to have_received(:store).with(42)
   end
+
+  context '#queue_as' do
+    it 'should value queue correctly' do
+      worker_class.queue_as('low')
+      expect(worker_class.queue).to be :low
+    end
+  end
 end


### PR DESCRIPTION
### WHY
We want to use queue_as in QT to match the ActiveJob format more