### PR TITLE
Plat 747 remove method name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).  
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).  
 
+## Unreleased
+
+- [PLAT-747] Remove the ability to pass through `method_name`
+
 ## 0.7.0
 
 - [PLAT-670] Add queue_as method

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Start by making a worker class which extends from BackgroundWorker::Base
 
 ```ruby
     class MyWorker < BackgroundWorker::Base
-      def my_task(options={})
+      def perform(options={})
         report_progress('Starting')
         if options[:message].blank?
           report_failed("No message provided")
@@ -27,7 +27,7 @@ Then, when you want to perform a task in the background, use
 klass#perform_in_background which exists in Base:
 
 ```ruby
-    worker_id = MyWorker.perform_in_background(:my_task, message: "hello!")
+    worker_id = MyWorker.perform_later(message: "hello!")
 ```
 
 # Backgrounded
@@ -37,8 +37,8 @@ provide an #enqueue_with configuration like so:
 
 ```ruby
     BackgroundWorker.configure(
-      enqueue_with: -> klass, method_name, options {
-        Resque.enqueue(klass, method_name, options)
+      enqueue_with: -> klass, options {
+        Resque.enqueue(klass, options)
       }
     )
 ```

--- a/lib/background_worker.rb
+++ b/lib/background_worker.rb
@@ -8,15 +8,15 @@ module BackgroundWorker
   # eg:
   # BackgroundWorker.configure(
   #   logger: Rails.logger,
-  #   enqueue_with: -> klass, method_name, opts { Resque.enqueue(klass, method_name, opts) },
+  #   enqueue_with: -> klass, opts { Resque.enqueue(klass, opts) },
   #   after_exception: -> e { Airbrake.notify(e) }
   # )
   def self.configure(options)
     @config = Config.new(options)
   end
 
-  def self.enqueue(klass, method_name, options)
-    config.enqueue_with.call(klass, method_name, options)
+  def self.enqueue(klass, options)
+    config.enqueue_with.call(klass, options)
   end
 
   def self.logger

--- a/lib/background_worker/config.rb
+++ b/lib/background_worker/config.rb
@@ -27,8 +27,8 @@ module BackgroundWorker
       @after_exception.call(e)
     end
 
-    def foreground_enqueue(klass, method_name, opts)
-      klass.perform_now(method_name, opts)
+    def foreground_enqueue(klass, opts)
+      klass.perform_now(opts)
     end
 
     def default_after_exception(e)

--- a/lib/background_worker/uid.rb
+++ b/lib/background_worker/uid.rb
@@ -1,11 +1,10 @@
 # Generates a unique identifier for a particular job identified by class_name/method
 module BackgroundWorker
   class Uid
-    attr_reader :class_name, :method
+    attr_reader :class_name
 
-    def initialize(class_name, method)
+    def initialize(class_name)
       @class_name = class_name
-      @method = method
     end
 
     def generate
@@ -15,11 +14,11 @@ module BackgroundWorker
     private
 
     def generate_uid_hash
-      ::Digest::MD5.hexdigest("#{class_name}:#{method}:#{rand(1 << 64)}:#{Time.now}")
+      ::Digest::MD5.hexdigest("#{class_name}:#{rand(1 << 64)}:#{Time.now}")
     end
 
     def generate_uid_name
-      "#{class_name.underscore}/#{method}".split('/').join(':')
+      "#{class_name.underscore}".split('/').join(':')
     end
   end
 end

--- a/lib/background_worker/worker_execution.rb
+++ b/lib/background_worker/worker_execution.rb
@@ -2,15 +2,14 @@ module BackgroundWorker
   class WorkerExecution
     attr_reader :worker, :method_name, :options
 
-    def initialize(worker, method_name, options)
+    def initialize(worker, options)
       fail ArgumentError, "'uid' is required to identify worker" unless options[:uid].present?
       @worker = worker
-      @method_name = method_name
       @options = options
     end
 
     def call
-      worker.send(method_name, options)
+      worker.perform(options)
       report_implicitly_successful unless completed?
 
     rescue StandardError => e

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -18,7 +18,7 @@ describe BackgroundWorker::Base do
   let(:model_class) { Model = Class.new(ActiveRecord::Base) }
   let(:worker_class) {
     Class.new(BackgroundWorker::Base) do
-      def store_in_cache(opts)
+      def perform(opts)
         Rails.cache.store(opts[:value])
       end
     end
@@ -32,7 +32,7 @@ describe BackgroundWorker::Base do
 
   it 'should perform action and handle transactions/connections appropriately' do
     Model.transaction do
-      worker_class.perform_later(:store_in_cache, value: 42)
+      worker_class.perform_later(value: 42)
     end
     expect(cache).to have_received(:store).with(42)
   end

--- a/spec/support/coverage_loader.rb
+++ b/spec/support/coverage_loader.rb
@@ -1,3 +1,3 @@
 require 'coverage/kit'
 
-Coverage::Kit.setup(minimum_coverage: 82.75)
+Coverage::Kit.setup(minimum_coverage: 82.30)

--- a/spec/uid_spec.rb
+++ b/spec/uid_spec.rb
@@ -2,11 +2,10 @@ require 'spec_helper'
 
 describe BackgroundWorker::Uid do
   let(:class_name) { 'CopyWorker' }
-  let(:method) { 'make_copy' }
-  let(:uid_object) { BackgroundWorker::Uid.new(class_name, method) }
+  let(:uid_object) { BackgroundWorker::Uid.new(class_name) }
 
   context '#generate' do
     subject(:uid) { uid_object.generate }
-    it { is_expected.to match(/copy_worker:make_copy:[0-9a-f]{16}/) }
+    it { is_expected.to match(/copy_worker:[0-9a-f]{16}/) }
   end
 end


### PR DESCRIPTION
### WHY

We are trying to match active job and only allow 1 job per class. This means we no longer have a requirement to allow multiple jobs per class and we can drop the method_name