### PR TITLE
[PLAT-761] Extract logging concern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 - [PLAT-749] Rename `uid` as `job_id` and make it a base property of job.
 - [PLAT-759] Add callbacks
+- [PLAT-761] Extract logging concern
 
 ## 0.8.1
 

--- a/lib/background_worker/base.rb
+++ b/lib/background_worker/base.rb
@@ -1,8 +1,10 @@
 require 'background_worker/persistent_state'
 require 'background_worker/worker_execution'
+require 'background_worker/logging_concern'
 
 module BackgroundWorker
   class Base
+    include BackgroundWorker::LoggingConcern
     attr_accessor :job_id, :state, :options
 
     def initialize(options = {})
@@ -61,15 +63,6 @@ module BackgroundWorker
     def report_failed(message = 'Failed', detailed_message = nil)
       state.detailed_message = detailed_message
       state.set_completed(message, :failed)
-    end
-
-    def logger
-      BackgroundWorker.logger
-    end
-
-    def log(message, options = {})
-      severity = options.fetch(:severity, :info)
-      logger.send(severity, "job_id=#{job_id} #{message}")
     end
 
     class << self

--- a/lib/background_worker/base.rb
+++ b/lib/background_worker/base.rb
@@ -1,10 +1,10 @@
 require 'background_worker/persistent_state'
 require 'background_worker/worker_execution'
-require 'background_worker/logging_concern'
+require 'background_worker/logging'
 
 module BackgroundWorker
   class Base
-    include BackgroundWorker::LoggingConcern
+    include BackgroundWorker::Logging
     attr_accessor :job_id, :state, :options
 
     def initialize(options = {})

--- a/lib/background_worker/logging.rb
+++ b/lib/background_worker/logging.rb
@@ -1,9 +1,8 @@
 require 'active_support/concern'
 
 module BackgroundWorker
-  module LoggingConcern
+  module Logging
     extend ActiveSupport::Concern
-    attr_reader :job_id
 
     def logger
       BackgroundWorker.logger

--- a/lib/background_worker/logging_concern.rb
+++ b/lib/background_worker/logging_concern.rb
@@ -1,0 +1,17 @@
+require 'active_support/concern'
+
+module BackgroundWorker
+  module LoggingConcern
+    extend ActiveSupport::Concern
+    attr_reader :job_id
+
+    def logger
+      BackgroundWorker.logger
+    end
+
+    def log(message, options = {})
+      severity = options.fetch(:severity, :info)
+      logger.send(severity, "job_id=#{job_id} #{message}")
+    end
+  end
+end

--- a/spec/support/coverage_loader.rb
+++ b/spec/support/coverage_loader.rb
@@ -1,3 +1,3 @@
 require 'coverage/kit'
 
-Coverage::Kit.setup(minimum_coverage: 81.80)
+Coverage::Kit.setup(minimum_coverage: 82.60)


### PR DESCRIPTION
### WHY
We need to extract logging functions from background_worker base so that we could use it independently