### PR TITLE
[PLAT-762] Perform now and later will return job object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 - [PLAT-759] Add callbacks
 - [PLAT-761] Extract logging concern
 - [PLAT-760] Extract status concern
+- [PLAT-762] Perform now and later will return job object
 
 ## 0.8.1
 

--- a/lib/background_worker/base.rb
+++ b/lib/background_worker/base.rb
@@ -47,18 +47,17 @@ module BackgroundWorker
         worker.before_enqueue
         BackgroundWorker.enqueue(self, worker.options.merge(job_id: worker.job_id))
         worker.after_enqueue
-        worker.job_id
+        worker
       end
 
       # This method is called by the job runner
-      #
-      # It will just call your preferred method in the worker.
       def perform_now(options = {})
         BackgroundWorker.verify_active_connections! if BackgroundWorker.config.backgrounded
 
         worker = new(options)
         execution = WorkerExecution.new(worker, options)
         execution.call
+        worker
       ensure
         BackgroundWorker.release_connections! if BackgroundWorker.config.backgrounded
       end


### PR DESCRIPTION
### WHY
We want perform_now and perform_later to return job object to match ActiveJob's behaviour